### PR TITLE
Fix bug when copying from the same file

### DIFF
--- a/deploy.ts
+++ b/deploy.ts
@@ -44,7 +44,12 @@ export async function switchEnvironment(branchName: string) {
     : DEFAULT_ENVIRONMENT;
 
   log(`Switching to environment '${useEnvironment.env}'...`);
-  copyFileSync(useEnvironment.env, "./.env.production");
+
+  // Don't copy to the same file - creates a blank file.
+  if (useEnvironment.env !== ".env.production") {
+    copyFileSync(useEnvironment.env, "./.env.production");
+  }
+
   require("dotenv").config({ path: "./.env.production" });
 }
 


### PR DESCRIPTION
If we copy from one file to the same file, this ends up creating a blank file (for example, from `.env.production` to `.env.production`), which then causes the deploy to fail. This should avoid the issue.